### PR TITLE
Merge mapcheck

### DIFF
--- a/bpfapp.c
+++ b/bpfapp.c
@@ -47,13 +47,11 @@ SEC("uprobe/SSL_read")
 int entry_ssl_read(void* ctx) {
     print_got_here("uprobe/SSL_read");
 
-    __u32 cafe = (__u32) 0xbebecafe;
-    count(&cafe, 0);
-
     __u32 pid = bpf_get_current_pid_tgid() >> 32;
     count(&pid, 0);
 
-    return 0;
+    __u32 cafe = (__u32) 0xbebecafe;
+    return count(&cafe, 0);
 }
 
 SEC("uretprobe/SSL_read")
@@ -61,9 +59,7 @@ int ret_ssl_read(void* ctx) {
     print_got_here("uretprobe/SSL_read");
 
     __u32 cafe = (__u32) 0xbebecafe;
-    count(&cafe, 1);
-
-    return 0;
+    return count(&cafe, 1);
 }
 
 char __license[] SEC("license") = "Dual MIT/GPL";

--- a/bpfapp.c
+++ b/bpfapp.c
@@ -32,7 +32,7 @@ static long count(__u32 *key, int isretprobe) {
             __u32 one = 1;
             return bpf_map_update_elem(&rcount, key, &one, BPF_NOEXIST);
         } else {
-            const static char m[] = "This is NULL!";
+            const static char m[] = "[ERROR] Trying to access map with nonexistent key from Uretprobe first";
             bpf_trace_printk(m, sizeof(m));
 
             return 1;
@@ -49,6 +49,9 @@ int entry_ssl_read(void* ctx) {
 
     __u32 cafe = (__u32) 0xbebecafe;
     count(&cafe, 0);
+
+    __u32 pid = bpf_get_current_pid_tgid() >> 32;
+    count(&pid, 0);
 
     return 0;
 }


### PR DESCRIPTION
Check for map access and not just printed traces as another evidence of the reversed order of execution for uprobes and uretprobes.